### PR TITLE
optimize the xtend of headers & allow request to override

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,13 +67,7 @@ Workload.prototype.stop = function stop () {
 Workload.prototype._visit = function _visit (req) {
   var self = this
 
-  req.headers = xtend(req.headers, this._defaultHeaders)
-
-  // Only set if user agent if it isn't set
-  //
-  if (typeof req.headers['user-agent'] === 'undefined') {
-    req.headers = xtend(req.headers, {'user-agent': USER_AGENT})
-  }
+  req.headers = xtend({'user-agent': USER_AGENT}, this._defaultHeaders, req.headers)
 
   request(req, function (err, res, body) {
     if (err) return self.emit('error', err)

--- a/test.js
+++ b/test.js
@@ -264,3 +264,29 @@ test('custom agent', function (t) {
     workload = new Workload(opts)
   })
 })
+
+test('custom header and filter header', function (t) {
+  t.plan(1)
+
+  var server = http.createServer(function (req, res) {
+    t.equal(req.headers.custom1, 'baz')
+    res.end()
+    workload.stop()
+    server.close()
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    var opts = {
+      max: 5 * 60,
+      headers: {custom1: 'foo'},
+      requests: [{url: 'http://localhost:' + port}],
+      filter: function (req, next) {
+        req.headers = {}
+        req.headers['custom1'] = 'baz'
+        next(req)
+      }
+    }
+    workload = new Workload(opts)
+  })
+})


### PR DESCRIPTION
Based on our slack convo -
1) Optimize the code for the setting of the headers, rather than test & multi-set
2) fix the logic so the readme stmt `headers - A object containing HTTP headers to use for the request (overrules options.headers)` works as advertised
3) added a TDD test to verify 2